### PR TITLE
opentelemetry-instrumentation-logging 0.59b0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-logging" %}
-{% set version = "0.58b0" %}
+{% set version = "0.59b0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 1475e531cf0e1c03e1c42995fcf312767edaadfe335d04d1d3b27c9a8c8c7049
+  sha256: 1b51116444edc74f699daf9002ded61529397100c9bc903c8b9aaa75a5218c76
 
 build:
   number: 0


### PR DESCRIPTION
opentelemetry-instrumentation-logging 0.59b0 

**Destination channel:** Defaults

### Links

- [PKG-11120]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python-contrib/tree/v0.59b0
- conda_forge:    https://github.com/conda-forge/opentelemetry-instrumentation-logging-feedstock
- pypi:           https://pypi.org/project/opentelemetry-instrumentation-logging/0.59b0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-instrumentation-logging/0.59b0

### Explanation of changes:

- new version number


[PKG-11120]: https://anaconda.atlassian.net/browse/PKG-11120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ